### PR TITLE
Make code files compatible with GCC compiler

### DIFF
--- a/Src/fat32.c
+++ b/Src/fat32.c
@@ -42,7 +42,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 //-------------------------------------------------------
 
-typedef __packed struct 
+typedef struct
 {
     uint8_t BS_jmpBoot[3];
     uint8_t BS_OEMName[8];
@@ -73,9 +73,9 @@ typedef __packed struct
     uint32_t BS_VolID;
     uint8_t BS_VolLab[11];
     uint8_t BS_FilSysType[8];
-}fat32_bpb_t;
+}__attribute__((packed)) fat32_bpb_t  ;
 
-typedef __packed struct 
+typedef struct
 {
     uint32_t FSI_LeadSig;
     uint8_t FSI_Reserved1[480];
@@ -84,9 +84,9 @@ typedef __packed struct
     uint32_t FSI_Nxt_Free;
     uint8_t FSI_Reserved2[12];
     uint32_t FSI_TrailSig;
-}fat32_fsinfo_t;
+}__attribute__((packed)) fat32_fsinfo_t  ;
 
-typedef __packed struct 
+typedef struct
 {
     uint8_t DIR_Name[11];
     uint8_t DIR_Attr;
@@ -101,7 +101,7 @@ typedef __packed struct
     uint16_t DIR_WrtDate;
     uint16_t DIR_FstClusLO;
     uint32_t DIR_FileSize;
-}fat32_dir_entry_t;
+}__attribute__((packed)) fat32_dir_entry_t  ;
 
 //-------------------------------------------------------
 

--- a/Src/main.c
+++ b/Src/main.c
@@ -99,8 +99,17 @@ extern PCD_HandleTypeDef hpcd_USB_FS;
 
 void SystemReset(){
     LL_mDelay(500);
+
     HAL_PCD_Stop(&hpcd_USB_FS);
+
+    /* Pull USB D+ PIN to GND so USB Host detects device disconnect */
+    LL_GPIO_SetPinMode(GPIOA,LL_GPIO_PIN_12, LL_GPIO_MODE_OUTPUT);
+    LL_GPIO_SetPinSpeed(GPIOA, LL_GPIO_PIN_12, LL_GPIO_SPEED_FREQ_LOW);
+    LL_GPIO_SetPinOutputType(GPIOA,LL_GPIO_PIN_12, LL_GPIO_OUTPUT_PUSHPULL);
+    LL_GPIO_ResetOutputPin(GPIOA, LL_GPIO_PIN_12);
+
     LL_mDelay(1000);
+
     NVIC_SystemReset();
 }
 


### PR DESCRIPTION
I recently ported the project to CubeIDE, which uses the GCC Compiler as standard.

For fat32.c, GCC exits with compiler error as it does not understand the syntax "typedef __packed struct ".
In order to make the file compile, the syntax of struct definition must be changed to "__attribute__((packed))". This is also a valid syntax for the compiler used by KEIL, which I just checked