### PR TITLE
Enhancement: Disconnect USB device properly when exit bootloader

### DIFF
--- a/Src/main.c
+++ b/Src/main.c
@@ -99,8 +99,17 @@ extern PCD_HandleTypeDef hpcd_USB_FS;
 
 void SystemReset(){
     LL_mDelay(500);
+
     HAL_PCD_Stop(&hpcd_USB_FS);
+
+    /* Pull USB D+ PIN to GND so USB Host detects device disconnect */
+    LL_GPIO_SetPinMode(GPIOA,LL_GPIO_PIN_12, LL_GPIO_MODE_OUTPUT);
+    LL_GPIO_SetPinSpeed(GPIOA, LL_GPIO_PIN_12, LL_GPIO_SPEED_FREQ_LOW);
+    LL_GPIO_SetPinOutputType(GPIOA,LL_GPIO_PIN_12, LL_GPIO_OUTPUT_PUSHPULL);
+    LL_GPIO_ResetOutputPin(GPIOA, LL_GPIO_PIN_12);
+
     LL_mDelay(1000);
+
     NVIC_SystemReset();
 }
 


### PR DESCRIPTION
When the bootloader is exited (e.g. for jumping to the main application), the USB Mass Storage Device should be disconnected properly from host computer. In my case, this is strictly necessary because my main application creates a new USB device (which would not be detected if the old device is not removed before).

In order to achieve that , it is necessary to pull the USB D+ Line to GND after calling HAL_PCD_Stop(&hpcd_USB_FS). Right afterwards, Windows detects the removal of the device.

This worked for me with Windows 7. If possible, it should also be tested with Windows 10.

(cherry picked from commit cefa2f4542ccb3629743645312d1af3f84075581)